### PR TITLE
🧹 [code health] Use unused variables in benchmark.js to prevent dead code elimination

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -39,6 +39,6 @@ for (let i = 0; i < N; i++) {
 const endNew = process.hrtime.bigint();
 const timeNewMs = Number(endNew - startNew) / 1000000;
 
-console.log(`Old digitalRoot: ${timeOldMs.toFixed(2)} ms`);
-console.log(`New digitalRoot: ${timeNewMs.toFixed(2)} ms`);
+console.log(`Old digitalRoot: ${timeOldMs.toFixed(2)} ms (sum=${sumOld})`);
+console.log(`New digitalRoot: ${timeNewMs.toFixed(2)} ms (sum=${sumNew})`);
 console.log(`Speedup: ${(timeOldMs / timeNewMs).toFixed(2)}x`);


### PR DESCRIPTION
This PR addresses a code health issue in `benchmark.js` where the variable `sumOld` was declared and incremented but never used. To resolve this and ensure the benchmark remains valid (preventing JIT compilers from optimizing away the computation loops), I have updated the final log statements to include the calculated sums.

Key changes:
- Log `sumOld` and `sumNew` in the final benchmark results.
- Verified that both sums are identical, confirming correctness.
- Confirmed that the benchmark still runs and provides meaningful performance comparisons.

---
*PR created automatically by Jules for task [7357755003560214164](https://jules.google.com/task/7357755003560214164) started by @korjavin*